### PR TITLE
fix: replace Titan with Claude 3.5 Haiku for tool use support

### DIFF
--- a/src/infrastructure/stacks/bedrock-agent-stack.ts
+++ b/src/infrastructure/stacks/bedrock-agent-stack.ts
@@ -35,8 +35,8 @@ export class BedrockAgentStack extends cdk.Stack {
                 'bedrock:InvokeModel',
               ],
               resources: [
-                // Amazon Titan Text G1 - Express (cheapest option)
-                `arn:aws:bedrock:${this.region}::foundation-model/amazon.titan-text-express-v1`,
+                // Claude 3.5 Haiku - cheapest model with tool use support
+                `arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-5-haiku-20241022-v1:0`,
               ],
             }),
           ],
@@ -170,7 +170,7 @@ export class BedrockAgentStack extends cdk.Stack {
     const agent = new bedrock.Agent(this, 'SampleAgent', {
       agentName: 'sample-text-agent',
       description: 'A sample Bedrock Agent for text processing and Q&A',
-      foundationModel: bedrock.BedrockFoundationModel.AMAZON_TITAN_TEXT_EXPRESS_V1,
+      foundationModel: bedrock.BedrockFoundationModel.ANTHROPIC_CLAUDE_3_5_HAIKU_V1_0,
       instruction: `You are a helpful assistant that can answer questions and process text.
       You have access to action groups that can perform specific tasks.
       Always be polite and helpful in your responses.


### PR DESCRIPTION
## Summary

Fixed Bedrock Agent model compatibility by replacing Amazon Titan Text G1 Express with Claude 3.5 Haiku, which supports tool use functionality required for Action Groups.

## Changes

- ✅ Updated foundation model from `amazon.titan-text-express-v1` to Claude 3.5 Haiku
- ✅ Claude 3.5 Haiku supports tool use while being cost-effective
- ✅ Updated IAM permissions ARN to match new model
- ✅ Build verified successfully

## Why This Change

Bedr ock Agents require models that support tool use (function calling) to work properly with Action Groups. Amazon Titan Text G1 Express does not support this feature, causing the agent to fail when trying to use the defined actions.

Claude 3.5 Haiku is the most cost-effective model in the Bedrock lineup that supports tool use.

## Testing

- [x] TypeScript build passes
- [x] CDK stack compiles without errors
- [ ] Manual deployment testing

Generated with [Claude Code](https://claude.ai/code)